### PR TITLE
base-orphans, GHC 7.10 compatibility

### DIFF
--- a/shady-gen.cabal
+++ b/shady-gen.cabal
@@ -24,7 +24,8 @@ Source-Repository head
 Library
   hs-Source-Dirs:      src
 
-  Build-Depends:       base >=4 && < 5, containers, mtl, wl-pprint
+  Build-Depends:       base >=4 && < 5, base-orphans >= 0.3.1
+                     , containers, mtl, wl-pprint
                      , applicative-numbers>=0.0.4, vector-space>=0.5.6
                      , TypeCompose >= 0.7
                      , MemoTrie, ty, data-treify, Boolean >= 0.1.0

--- a/src/Shady/Language/Exp.hs
+++ b/src/Shady/Language/Exp.hs
@@ -1,12 +1,11 @@
 {-# LANGUAGE GADTs, RankNTypes, KindSignatures, TypeOperators
-           , StandaloneDeriving, GeneralizedNewtypeDeriving
            , PatternGuards, ScopedTypeVariables
            , FlexibleContexts, FlexibleInstances
            , TypeFamilies, TypeSynonymInstances
            , MultiParamTypeClasses, UndecidableInstances
            , EmptyDataDecls, CPP
   #-}
-{-# OPTIONS_GHC -Wall -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wall #-}
 ----------------------------------------------------------------------
 -- |
 -- Module      :  Shady.Language.Exp
@@ -60,6 +59,7 @@ module Shady.Language.Exp
   )
   where
 
+import Data.Orphans ()
 import Data.Monoid (Monoid(..),First(..))
 import Data.Maybe (fromMaybe)
 import Control.Applicative (Applicative(pure),(<$>))
@@ -85,14 +85,13 @@ import Shady.Language.Operator
 import Shady.Misc
 import Shady.Complex
 
+#if MIN_VERSION_base(4,8,0)
+import Prelude hiding ((<*))
+#endif
 
 {--------------------------------------------------------------------
     Strays
 --------------------------------------------------------------------}
-
-deriving instance Functor     First
-deriving instance Applicative First
-deriving instance Monad       First
 
 fromFirst :: a -> First a -> a
 fromFirst a = fromMaybe a . getFirst

--- a/src/Shady/Language/Type.hs
+++ b/src/Shady/Language/Type.hs
@@ -50,6 +50,7 @@ import Data.Foldable (toList)
 import Control.Monad.Instances ()
 import Foreign.Storable
 
+import Data.Orphans ()
 import Data.Typeable (Typeable)
 
 import Text.PrettyPrint.Leijen
@@ -327,9 +328,6 @@ instance Eq x => SynEq (Const x) where (=-=) = (==)
 -- | Higher-order variant of 'SynEq'.  Can be defined via '(=-=)', or vice versa.
 class SynEq2 f where
   (=--=) :: (SynEq v, HasType c) => f v c -> f v c -> Bool
-
-
-deriving instance Eq a => Eq (Const a b)
 
 
 {--------------------------------------------------------------------


### PR DESCRIPTION
This pull request hides `(<*)` from `Prelude` if using GHC 7.10's version of `base`, and consolidates orphan instances using `base-orphans`.
